### PR TITLE
fix: ICT Exchange

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 ca/config/ca.json
 .secrets
 .env
+.idea/

--- a/Dockerfile
+++ b/Dockerfile
@@ -23,7 +23,9 @@ RUN go build -a -ldflags '-linkmode external -extldflags "-static"' -o /go/src/o
 
 
 # Generate runtime container
-FROM scratch AS runtime
+FROM alpine:3.21 AS runtime
+
+RUN apk add --no-cache ca-certificates
 
 # Create working directory for binary
 WORKDIR /

--- a/README.md
+++ b/README.md
@@ -50,8 +50,30 @@ If the client performs a token exchange request `requested_token_type=urn:ietf:p
 ```
 **Figure 2**: Identity Certification Token request.
 
+### 1.1. ICT and DPoP (strict policy)
+
+For **ICT token exchange** (`grant_type=urn:ietf:params:oauth:grant-type:token-exchange` and `requested_token_type=urn:ietf:params:oauth:token-type:ic_token`, or omitted `requested_token_type`), the middleware enforces:
+
+1. **Subject token** must be a **DPoP-bound access token** (`cnf.jkt` in introspection or in the JWT payload).
+2. The client must send a valid **`DPoP` proof** for the ICT POST (`htm=POST`, `htu` = middleware token URL).
+3. The proof’s public key must match the subject token’s `cnf.jkt`.
+
+Bearer-only subject tokens are **rejected** for ICT. The issued ICT always includes `cnf.jkt` carrying forward the binding.
+
+All **other** token requests (authorization code, refresh, non-ICT token exchange, etc.) are **proxied to Keycloak** as-is; DPoP is optional on those forwarded calls.
+
 ## 2. Setup
-The provided [Docker composition](./docker-compose.yaml) contains an example for the following software:
+
+There are two ways to run the middleware locally:
+
+| Setup | Compose file | OpenID Provider | Typical use |
+|-------|--------------|-----------------|-------------|
+| **Full stack** | [`docker-compose.yaml`](./docker-compose.yaml) | Local Keycloak + Traefik + internal CA | Integration tests, Swagger/Postman against `op.localhost` |
+| **Middleware only** | [`compose-dev.yaml`](./compose-dev.yaml) | External / deployed Keycloak (e.g. `https://sso.koala.primbs.dev/realms/koala`) | Koala client dev, ICT exchange against a real realm |
+
+### 2.1. Full stack (`docker-compose.yaml`)
+
+The composition includes:
 
 - Reverse Proxy: [Traefik Proxy](https://traefik.io/traefik/)
 - OpenID Provider: [Keycloak](https://www.keycloak.org/)
@@ -59,8 +81,11 @@ The provided [Docker composition](./docker-compose.yaml) contains an example for
 
 First, copy the file [`example.env`](./example.env`) to `.env` and adjust its [configuration](#configuration) parameters:
 ```bash
-copy example.env .env
-nano .env
+# Local test stack (internal CA, op.localhost):
+cp example-test.env .env
+
+# Or production-style stack:
+# cp example-prod.env .env
 ```
 
 Then, generate your secret files:
@@ -77,21 +102,39 @@ If you run the service locally, you should import the generated root certificate
 Then, use the following command to run the composition in the required profile:
 ```bash
 # Start the composition in detached mode (-d):
-docker compose --profile "test" up -d
+docker compose --profile test up -d   # local test
+docker compose --profile dev up -d    # local dev (builds middleware from source)
+docker compose --profile prod up -d   # production-style
 ```
-
-Available profiles are:
-- `prod`: Public production mode
-- `test`: Local test mode
-- `dev`: Local development mode
 
 To stop the composition, use the following command:
 ```bash
 # Stop the composition:
-docker compose --profile "test" down
+docker compose --profile test down
 ```
 
-See step-by-step guide [here](./docs-dev/setup.md).
+See the step-by-step guide for the full stack [here](./docs-dev/setup.md).
+
+### 2.2. Middleware only (`compose-dev.yaml`)
+
+Use this when Keycloak already runs elsewhere and you only need the OIDC^2 middleware on your machine (e.g. Koala client with `LOCAL_OIDC2_ICT_ENDPOINT=http://localhost:8082`).
+
+1. Copy [`example-dev.env`](./example-dev.env) to `.env` and set `ISSUER`, the three endpoint URLs, `KEY_ID`, `INTROSPECTION_CREDENTIALS`, and `ALLOWED_ORIGINS` for your realm.
+2. Start the middleware:
+
+```bash
+docker compose -f compose-dev.yaml up --build -d oidc2middleware
+```
+
+The service listens on **host port 8082** (`8082:8080`). POST token requests to `http://localhost:8082/`.
+
+The optional `app` service in the same file is a [Docker Dev Environment](https://docs.docker.com/dev/) shell (`dev.Dockerfile`); start it only if you need that IDE container:
+
+```bash
+docker compose -f compose-dev.yaml up -d app
+```
+
+See [docs-dev/setup.md](./docs-dev/setup.md#middleware-only-external-keycloak) for details.
 
 ## 3. Configuration
 Apply the following configuration options in your `.env` file.
@@ -241,6 +284,37 @@ HOSTS=127.0.0.1,::1
 ```
 
 Default value is `0.0.0.0` (all IPv4 hosts).
+
+#### 3.4.3. Introspection credentials
+HTTP `Authorization` header value for the Token Introspection request (e.g. Keycloak confidential client).
+
+Example:
+
+```bash
+INTROSPECTION_CREDENTIALS="Basic <base64(client_id:client_secret)>"
+```
+
+#### 3.4.4. Allowed origins (CORS)
+Comma-separated list of `Origin` header values allowed for browser clients.
+
+Example:
+
+```bash
+ALLOWED_ORIGINS=https://koala-local,https://koala.primbs.dev
+```
+
+Optional. Native clients usually do not send `Origin`; this matters mainly for web clients.
+
+#### 3.4.5. DPoP proof max age
+Maximum age in seconds for a DPoP proof `iat` claim when the subject token is DPoP-bound.
+
+Example:
+
+```bash
+DPOP_MAX_AGE=300
+```
+
+Default is `300`.
 
 ## 4. REST Documentation
 The [OpenAPI](https://swagger.io/specification/) documentation of the RESTful API is provided [here](./api/oidc2middleware.yaml).

--- a/compose-dev.yaml
+++ b/compose-dev.yaml
@@ -13,3 +13,16 @@ services:
         source: /var/run/docker.sock
         target: /var/run/docker.sock
 
+  oidc2middleware:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8082:8080"
+    env_file:
+      - .env
+    environment:
+      KEY_FILE: /secrets/op_private.key
+    volumes:
+      - ./.secrets:/secrets:ro
+

--- a/example-dev.env
+++ b/example-dev.env
@@ -17,11 +17,23 @@ OP_HOST=op.localhost
 # See README.md for more information on how to use this example.
 
 # Required configuration:
-KEY_FILE=/secrets/private_key.pem
+KEY_FILE=/secrets/op_private.key
 KEY_ID=1
 
 # Optional configuration:
-ALG=ES256
+ALG=RS256
 TOKEN_PERIOD=3600
 DPOP_MAX_AGE=300
 ALLOWED_ORIGINS=https://koala-local,https://koala.primbs.dev
+
+# OpenID Provider (external / deployed Keycloak)
+ISSUER=https://sso.koala.primbs.dev/realms/koala
+
+# Explicitly set all three endpoints to skip discovery at startup
+# Remove these three lines to let the middleware discover them from ISSUER
+TOKEN_ENDPOINT=https://sso.example.com/realms/your-realm/protocol/openid-connect/token
+INTROSPECTION_ENDPOINT=https://sso.example.com/realms/your-realm/protocol/openid-connect/token/introspect
+USERINFO_ENDPOINT=https://sso.example.com/realms/your-realm/protocol/openid-connect/userinfo
+
+# Basic auth credentials for the Keycloak introspection endpoint.
+INTROSPECTION_CREDENTIALS=Basic <base64(client_id:client_secret)>

--- a/go/api_default.go
+++ b/go/api_default.go
@@ -87,37 +87,9 @@ func (c *DefaultAPIController) TokenRequest(w http.ResponseWriter, r *http.Reque
 		return
 	}
 
-	grantTypeParam := r.FormValue("grant_type")
-
-	clientIdParam := r.FormValue("client_id")
-
-	codeParam := r.FormValue("code")
-
-	redirectUriParam := r.FormValue("redirect_uri")
-
-	clientSecretParam := r.FormValue("client_secret")
-
-	refreshTokenParam := r.FormValue("refresh_token")
-
-	scopeParam := r.FormValue("scope")
-
-	resourceParam := r.FormValue("resource")
-
-	audienceParam := r.FormValue("audience")
-
-	subjectTokenParam := r.FormValue("subject_token")
-
-	subjectTokenTypeParam := r.FormValue("subject_token_type")
-	
-	requestedTokenTypeParam := r.FormValue("requested_token_type")
-
-	actorTokenParam := r.FormValue("actor_token")
-
-	actorTokenTypeParam := r.FormValue("actor_token_type")
-
 	// Accept DPoP proof from the standard DPoP HTTP header
 	dpopParam := r.Header.Get("DPoP")
-
+	
 	authorizationParam := r.Header.Get("Authorization")
 
 	// Reconstruct the full request URL so the service can validate the DPoP htu claim
@@ -139,7 +111,26 @@ func (c *DefaultAPIController) TokenRequest(w http.ResponseWriter, r *http.Reque
 	}
 	requestURLParam := scheme + "://" + host + path
 
-	result, err := c.service.TokenRequest(r.Context(), grantTypeParam, clientIdParam, codeParam, redirectUriParam, clientSecretParam, refreshTokenParam, scopeParam, resourceParam, audienceParam, subjectTokenParam, subjectTokenTypeParam, requestedTokenTypeParam, actorTokenParam, actorTokenTypeParam, dpopParam, authorizationParam, requestURLParam)
+	result, err := c.service.TokenRequest(
+		r.Context(),
+		r.FormValue("grant_type"),
+		r.FormValue("client_id"),
+		r.FormValue("code"),
+		r.FormValue("redirect_uri"),
+		r.FormValue("client_secret"),
+		r.FormValue("refresh_token"),
+		r.FormValue("scope"),
+		r.FormValue("resource"),
+		r.FormValue("audience"),
+		r.FormValue("subject_token"),
+		r.FormValue("subject_token_type"),
+		r.FormValue("requested_token_type"),
+		r.FormValue("actor_token"),
+		r.FormValue("actor_token_type"),
+		dpopParam,
+		authorizationParam,
+		requestURLParam,
+	)
 	// If an error occurred, encode the error with the status code
 	if err != nil {
 		c.errorHandler(w, r, err, &result)

--- a/go/api_default_service.go
+++ b/go/api_default_service.go
@@ -73,9 +73,6 @@ func (s *DefaultAPIService) TokenRequest(ctx context.Context, grantType string, 
 	if subjectTokenType != "" && subjectTokenType != "urn:ietf:params:oauth:token-type:access_token" {
 		return oauthError(http.StatusBadRequest, "invalid_request", "subject_token_type must identify an access token"), nil
 	}
-	if dpop == "" {
-		return oauthError(http.StatusBadRequest, "invalid_dpop_proof", "dpop proof is required for DPoP-bound subject tokens"), nil
-	}
 
 	introspection, errResp := introspectToken(ctx, cfg, subjectToken)
 	if errResp != nil {
@@ -84,22 +81,30 @@ func (s *DefaultAPIService) TokenRequest(ctx context.Context, grantType string, 
 	if !introspection.Active {
 		return oauthError(http.StatusBadRequest, "invalid_grant", "subject_token is inactive"), nil
 	}
-	if !introspection.IsDPoPToken() {
-		return oauthError(http.StatusBadRequest, "invalid_grant", "subject_token is not a DPoP access token"), nil
-	}
 	if scope != "" && !hasRequiredScopes(introspection.Scope, scope) {
 		return oauthError(http.StatusForbidden, "insufficient_scope", "subject_token does not contain the required scope"), nil
 	}
 
-	_, err := validateDPoPProof(dpop, introspection.Cnf.Jkt, requestURL)
-	if err != nil {
+	subjectJkt := resolveSubjectTokenJkt(introspection, subjectToken)
+	if subjectJkt == "" {
+		return oauthError(
+			http.StatusBadRequest,
+			"invalid_token",
+			"subject_token must be a DPoP-bound access token (cnf.jkt required for ICT exchange)",
+		), nil
+	}
+	if strings.TrimSpace(dpop) == "" {
+		return oauthError(
+			http.StatusBadRequest,
+			"invalid_dpop_proof",
+			"DPoP proof header is required for ICT token exchange",
+		), nil
+	}
+	if _, err := validateDPoPProof(dpop, subjectJkt, requestURL); err != nil {
 		return oauthError(http.StatusBadRequest, "invalid_dpop_proof", err.Error()), nil
 	}
-
-	userInfo, errResp := fetchUserInfo(ctx, cfg, subjectToken)
-	if errResp != nil {
-		return *errResp, nil
-	}
+	introspection.Cnf.Jkt = subjectJkt
+	userInfo := userInfoFromIntrospection(introspection)
 
 	issuedAt := time.Now().UTC()
 	expiresAt := issuedAt.Add(time.Duration(cfg.TokenPeriod) * time.Second)
@@ -188,6 +193,42 @@ func (r *introspectionResponse) UnmarshalJSON(data []byte) error {
 
 func (r introspectionResponse) IsDPoPToken() bool {
 	return strings.EqualFold(r.TokenType, "DPoP") || r.Cnf.Jkt != ""
+}
+
+// Returns the confirmation thumbprint for subjectToken
+func resolveSubjectTokenJkt(introspection *introspectionResponse, subjectToken string) string {
+	if introspection.Cnf.Jkt != "" {
+		return introspection.Cnf.Jkt
+	}
+	return jktFromAccessTokenJWT(subjectToken)
+}
+
+func jktFromAccessTokenJWT(accessToken string) string {
+	parts := strings.Split(accessToken, ".")
+	if len(parts) != 3 {
+		return ""
+	}
+	payload, err := decodeBase64URLField(parts[1])
+	if err != nil {
+		return ""
+	}
+	var claims map[string]interface{}
+	if err := json.Unmarshal(payload, &claims); err != nil {
+		return ""
+	}
+	cnf, ok := claims["cnf"].(map[string]interface{})
+	if !ok {
+		return ""
+	}
+	jkt, _ := cnf["jkt"].(string)
+	return strings.TrimSpace(jkt)
+}
+
+func jktLogPrefix(jkt string) string {
+	if len(jkt) <= 8 {
+		return jkt
+	}
+	return jkt[:8]
 }
 
 type dpopProofClaims struct {
@@ -412,6 +453,21 @@ func validateDPoPProof(raw string, expectedJKT string, expectedHTU string) (*dpo
 	return claims, nil
 }
 
+// Maps introspection fields into ICT claim inputs
+func userInfoFromIntrospection(introspection *introspectionResponse) map[string]interface{} {
+	userInfo := map[string]interface{}{}
+	if introspection.Sub != "" {
+		userInfo["sub"] = introspection.Sub
+	}
+	if introspection.Username != "" {
+		userInfo["preferred_username"] = introspection.Username
+	}
+	for key, value := range introspection.Extra {
+		userInfo[key] = value
+	}
+	return userInfo
+}
+
 func fetchUserInfo(ctx context.Context, cfg *AppConfiguration, subjectToken string) (map[string]interface{}, *ImplResponse) {
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, cfg.UserInfoEndpoint, nil)
 	if err != nil {
@@ -573,11 +629,11 @@ func publicKeyFromJWK(jwk map[string]interface{}) (interface{}, error) {
 		crv, _ := jwk["crv"].(string)
 		xStr, _ := jwk["x"].(string)
 		yStr, _ := jwk["y"].(string)
-		xBytes, err := base64.RawURLEncoding.DecodeString(xStr)
+		xBytes, err := decodeBase64URLField(xStr)
 		if err != nil {
 			return nil, err
 		}
-		yBytes, err := base64.RawURLEncoding.DecodeString(yStr)
+		yBytes, err := decodeBase64URLField(yStr)
 		if err != nil {
 			return nil, err
 		}
@@ -593,11 +649,11 @@ func publicKeyFromJWK(jwk map[string]interface{}) (interface{}, error) {
 	case "RSA":
 		nStr, _ := jwk["n"].(string)
 		eStr, _ := jwk["e"].(string)
-		nBytes, err := base64.RawURLEncoding.DecodeString(nStr)
+		nBytes, err := decodeBase64URLField(nStr)
 		if err != nil {
 			return nil, err
 		}
-		eBytes, err := base64.RawURLEncoding.DecodeString(eStr)
+		eBytes, err := decodeBase64URLField(eStr)
 		if err != nil {
 			return nil, err
 		}
@@ -615,7 +671,7 @@ func publicKeyFromJWK(jwk map[string]interface{}) (interface{}, error) {
 			return nil, fmt.Errorf("unsupported OKP curve %q", crv)
 		}
 		xStr, _ := jwk["x"].(string)
-		xBytes, err := base64.RawURLEncoding.DecodeString(xStr)
+		xBytes, err := decodeBase64URLField(xStr)
 		if err != nil {
 			return nil, err
 		}
@@ -634,21 +690,25 @@ func jwkThumbprint(jwk map[string]interface{}) (string, error) {
 	return base64.RawURLEncoding.EncodeToString(sum[:]), nil
 }
 
+func trimJWKEncoding(s string) string {
+	return strings.TrimRight(strings.TrimSpace(s), "=")
+}
+
 func canonicalJWK(jwk map[string]interface{}) (string, error) {
 	kty, _ := jwk["kty"].(string)
 	switch kty {
 	case "EC":
 		crv, _ := jwk["crv"].(string)
-		x, _ := jwk["x"].(string)
-		y, _ := jwk["y"].(string)
+		x := trimJWKEncoding(jwk["x"].(string))
+		y := trimJWKEncoding(jwk["y"].(string))
 		return fmt.Sprintf("{\"crv\":\"%s\",\"kty\":\"EC\",\"x\":\"%s\",\"y\":\"%s\"}", crv, x, y), nil
 	case "RSA":
-		e, _ := jwk["e"].(string)
-		n, _ := jwk["n"].(string)
+		e := trimJWKEncoding(jwk["e"].(string))
+		n := trimJWKEncoding(jwk["n"].(string))
 		return fmt.Sprintf("{\"e\":\"%s\",\"kty\":\"RSA\",\"n\":\"%s\"}", e, n), nil
 	case "OKP":
 		crv, _ := jwk["crv"].(string)
-		x, _ := jwk["x"].(string)
+		x := trimJWKEncoding(jwk["x"].(string))
 		return fmt.Sprintf("{\"crv\":\"%s\",\"kty\":\"OKP\",\"x\":\"%s\"}", crv, x), nil
 	default:
 		return "", fmt.Errorf("unsupported jwk key type %q", kty)

--- a/go/helpers.go
+++ b/go/helpers.go
@@ -9,6 +9,7 @@
 package oidc2middleware
 
 import (
+	"encoding/base64"
 	"encoding/json"
 	"errors"
 	"io"
@@ -23,6 +24,12 @@ import (
 )
 
 const errMsgRequiredMissing = "required parameter is missing"
+
+// Decodes unpadded base64url
+func decodeBase64URLField(s string) ([]byte, error) {
+	s = strings.TrimRight(strings.TrimSpace(s), "=")
+	return base64.RawURLEncoding.DecodeString(s)
+}
 const errMsgMinValueConstraint = "provided parameter is not respecting minimum value constraint"
 const errMsgMaxValueConstraint = "provided parameter is not respecting maximum value constraint"
 


### PR DESCRIPTION
## What
- Fixes ICT Exchange for DPoP bound ATs
- Skips Keycloak userinfo for DPoP bound subjects and build ICT claims from introspection   
- Fixes DPoP JWK decoding when base64url padding was used
#### Additional Changes:
   - Introduced `compose-dev.yaml` for local setup with middleware on port `8082` and an external Keycloak
   - Updated Docs for local setup and other information
   
## Why
- There were issues with the ICT Exchange from the Koala Client
   - Koala sends DPoP bound ATs as subject_token, not a plain Bearer token!
   - Keycloak userinfo failed for DPoP bound tokens with `Authorization: Bearer`
   -  Padded JWK x / y values broke Go RawURLEncoding during DPoP proof verification

## How
- After introspection, require `cnf.jkt` (from introspection or the access token JWT)
- Require and validate the DPoP header
- Build ICT claims with `userInfoFromIntrospection` instead of calling userinfo
- Always include `cnf.jkt`  on the ICT
- Non-ICT requests still go to Keycloak via `forwardsTokenRequest` with an optional DPoP

## Testing
- Tested from the Koala Client with the local Middleware and a deployed Keycloak
   - An additional DPoP bound Token is used in the Koala Client to not affect the other auth flow where a non-DPoP Token is required 
   - With this DPoP Token, a ICT was successfully retrieved! :)
      - (With not affecting any other flow in the Koala Client)   
- As soon as this PR is merged and the Middleware is active on the Test Server again, this can be tested on the deployed Middleware 