### PR TITLE
feat: Add ctx claim to ICT

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,6 +263,14 @@ TOKEN_PERIOD=300
 
 Default value is `300` (5 minutes).
 
+#### 3.3.3. Authorized-party context mapping (`ATH_CTX`)
+
+When set, the middleware adds a `ctx` claim to issued ICTs based on the subject token's authorized party (`azp` from token introspection, falling back to `client_id`).
+
+The value is a JSON object mapping `azp` strings to arrays of context strings.
+
+If `ATH_CTX` is configured and the subject token's authorized party has no entry, the ICT exchange is rejected.
+
 ### 3.4. Hosting Configuration
 
 #### 3.4.1. Port

--- a/example-dev.env
+++ b/example-dev.env
@@ -37,3 +37,6 @@ USERINFO_ENDPOINT=https://sso.example.com/realms/your-realm/protocol/openid-conn
 
 # Basic auth credentials for the Keycloak introspection endpoint.
 INTROSPECTION_CREDENTIALS=Basic <base64(client_id:client_secret)>
+
+# Maps authorized party (azp from subject token introspection) to ICT ctx claim values
+ATH_CTX={"koala-android": ["koala-keys", "koala-signalling"], "koala-windows": ["koala-keys", "koala-signalling"]}

--- a/go/api_default_service.go
+++ b/go/api_default_service.go
@@ -106,9 +106,14 @@ func (s *DefaultAPIService) TokenRequest(ctx context.Context, grantType string, 
 	introspection.Cnf.Jkt = subjectJkt
 	userInfo := userInfoFromIntrospection(introspection)
 
+	ctxClaims, errResp := resolveCtxClaims(cfg, introspection)
+	if errResp != nil {
+		return *errResp, nil
+	}
+
 	issuedAt := time.Now().UTC()
 	expiresAt := issuedAt.Add(time.Duration(cfg.TokenPeriod) * time.Second)
-	ict, err := issueICT(cfg, clientId, introspection, userInfo, issuedAt, expiresAt)
+	ict, err := issueICT(cfg, clientId, introspection, userInfo, ctxClaims, issuedAt, expiresAt)
 	if err != nil {
 		return Response(http.StatusInternalServerError, ErrorStatus{
 			Error:            "server_error",
@@ -148,6 +153,7 @@ type introspectionResponse struct {
 	Active    bool                   `json:"active"`
 	Scope     string                 `json:"scope"`
 	ClientID  string                 `json:"client_id"`
+	Azp       string                 `json:"azp"`
 	Username  string                 `json:"username"`
 	TokenType string                 `json:"token_type"`
 	Sub       string                 `json:"sub"`
@@ -177,6 +183,7 @@ func (r *introspectionResponse) UnmarshalJSON(data []byte) error {
 	delete(extra, "active")
 	delete(extra, "scope")
 	delete(extra, "client_id")
+	delete(extra, "azp")
 	delete(extra, "username")
 	delete(extra, "token_type")
 	delete(extra, "sub")
@@ -454,6 +461,30 @@ func validateDPoPProof(raw string, expectedJKT string, expectedHTU string) (*dpo
 }
 
 // Maps introspection fields into ICT claim inputs
+func (r *introspectionResponse) authorizedParty() string {
+	if strings.TrimSpace(r.Azp) != "" {
+		return strings.TrimSpace(r.Azp)
+	}
+	return strings.TrimSpace(r.ClientID)
+}
+
+func resolveCtxClaims(cfg *AppConfiguration, introspection *introspectionResponse) ([]string, *ImplResponse) {
+	if len(cfg.AthCtx) == 0 {
+		return nil, nil
+	}
+	azp := introspection.authorizedParty()
+	if azp == "" {
+		resp := oauthError(http.StatusBadRequest, "invalid_token", "subject_token is missing authorized party (azp)")
+		return nil, &resp
+	}
+	ctxClaims, ok := cfg.AthCtx[azp]
+	if !ok {
+		resp := oauthError(http.StatusForbidden, "invalid_client", fmt.Sprintf("no ctx mapping configured for authorized party %q", azp))
+		return nil, &resp
+	}
+	return ctxClaims, nil
+}
+
 func userInfoFromIntrospection(introspection *introspectionResponse) map[string]interface{} {
 	userInfo := map[string]interface{}{}
 	if introspection.Sub != "" {
@@ -516,7 +547,7 @@ func fetchUserInfo(ctx context.Context, cfg *AppConfiguration, subjectToken stri
 	return payload, nil
 }
 
-func issueICT(cfg *AppConfiguration, clientID string, introspection *introspectionResponse, userInfo map[string]interface{}, issuedAt time.Time, expiresAt time.Time) (string, error) {
+func issueICT(cfg *AppConfiguration, clientID string, introspection *introspectionResponse, userInfo map[string]interface{}, ctxClaims []string, issuedAt time.Time, expiresAt time.Time) (string, error) {
 	signingKey, err := loadSigningKey(cfg)
 	if err != nil {
 		return "", err
@@ -537,6 +568,9 @@ func issueICT(cfg *AppConfiguration, clientID string, introspection *introspecti
 	}
 	if introspection.ClientID != "" {
 		claims["client_id"] = introspection.ClientID
+	}
+	if len(ctxClaims) > 0 {
+		claims["ctx"] = ctxClaims
 	}
 	for key, value := range userInfo {
 		if _, exists := claims[key]; !exists {

--- a/go/app_configuration.go
+++ b/go/app_configuration.go
@@ -9,6 +9,7 @@
 package oidc2middleware
 
 import (
+	"encoding/json"
 	"errors"
 	"net"
 	"os"
@@ -28,6 +29,7 @@ type AppConfiguration struct {
 	TokenPeriod           int
 	Port                  int
 	Listeners             []string
+	AthCtx map[string][]string
 }
 
 var Configuration *AppConfiguration
@@ -86,6 +88,11 @@ func LoadConfigurationFromEnv() (*AppConfiguration, error) {
 		}
 	}
 
+	athCtx, err := parseAthCtx(os.Getenv("ATH_CTX"))
+	if err != nil {
+		return nil, err
+	}
+
 	return &AppConfiguration{
 		KeyFile:               keyFile,
 		KeyID:                 keyID,
@@ -97,7 +104,20 @@ func LoadConfigurationFromEnv() (*AppConfiguration, error) {
 		TokenPeriod:           tokenPeriod,
 		Port:                  port,
 		Listeners:             parseListeners(getEnvOrDefault("HOSTS", "0.0.0.0")),
+		AthCtx:                athCtx,
 	}, nil
+}
+
+func parseAthCtx(raw string) (map[string][]string, error) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return nil, nil
+	}
+	var parsed map[string][]string
+	if err := json.Unmarshal([]byte(raw), &parsed); err != nil {
+		return nil, errors.New("invalid ATH_CTX: must be JSON object mapping azp to string arrays")
+	}
+	return parsed, nil
 }
 
 func getEnvOrDefault(key, defaultValue string) string {


### PR DESCRIPTION
## What?
- Added support to include `ctx` claim in generated ICT Tokens
- The value is taken from `ATH_CTX` config and selected by authorized party `azp`  (fallback `client_id`) from introspection

## Why?
- ICT needs to carry context information for each client, to avoid them being used in a wrong way
    - Specifically, to check the ctx `koala-keys` for key requests to the Keyserver

## How?
- `ATH_CTX` is the config as a JSON Map set in the env
    - It maps azp -> list of ctx strings
- During token exchange, server resolves azp from introspection and gets matching `ctx` values
   -  If mapping exists, `ctx` is added to ICT claims
   - If `ATH_CTX` is set but no match exists, exchange is rejected