### PR TITLE
fix: Forward entire form body to Keycloak

### DIFF
--- a/go/api.go
+++ b/go/api.go
@@ -11,6 +11,7 @@ package oidc2middleware
 import (
 	"context"
 	"net/http"
+	"net/url"
 )
 
 // DefaultAPIRouter defines the required methods for binding the api requests to a responses for the DefaultAPI
@@ -26,6 +27,6 @@ type DefaultAPIRouter interface {
 // while the service implementation can be ignored with the .openapi-generator-ignore file
 // and updated with the logic required for the API.
 type DefaultAPIServicer interface {
-	TokenRequest(context.Context, string, string, string, string, string, string, string, string, string, string, string, string, string, string, string, string, string) (ImplResponse, error)
+	TokenRequest(context.Context, url.Values, string, string, string, string, string, string, string, string, string, string, string, string, string, string, string, string, string) (ImplResponse, error)
 	TokenRequestPreflight(context.Context) (ImplResponse, error)
 }

--- a/go/api_default.go
+++ b/go/api_default.go
@@ -113,6 +113,7 @@ func (c *DefaultAPIController) TokenRequest(w http.ResponseWriter, r *http.Reque
 
 	result, err := c.service.TokenRequest(
 		r.Context(),
+		r.PostForm,
 		r.FormValue("grant_type"),
 		r.FormValue("client_id"),
 		r.FormValue("code"),

--- a/go/api_default_service.go
+++ b/go/api_default_service.go
@@ -44,27 +44,12 @@ func NewDefaultAPIService() *DefaultAPIService {
 }
 
 // TokenRequest - Request a token.
-func (s *DefaultAPIService) TokenRequest(ctx context.Context, grantType string, clientId string, code string, redirectUri string, clientSecret string, refreshToken string, scope string, resource string, audience string, subjectToken string, subjectTokenType string, requestedTokenType string, actorToken string, actorTokenType string, dpop string, authorizationHeader string, requestURL string) (ImplResponse, error) {
+func (s *DefaultAPIService) TokenRequest(ctx context.Context, postForm url.Values, grantType string, clientId string, code string, redirectUri string, clientSecret string, refreshToken string, scope string, resource string, audience string, subjectToken string, subjectTokenType string, requestedTokenType string, actorToken string, actorTokenType string, dpop string, authorizationHeader string, requestURL string) (ImplResponse, error) {
 	cfg := Configuration
 
 	if !isICTRequest(grantType, requestedTokenType) {
 		log.Printf("Received non-ICT token request with grant_type=%q requested_token_type=%q, forwarding to token endpoint", grantType, requestedTokenType)
-		return forwardTokenRequest(ctx, cfg, map[string]string{
-			"grant_type":         grantType,
-			"client_id":          clientId,
-			"code":               code,
-			"redirect_uri":       redirectUri,
-			"client_secret":      clientSecret,
-			"refresh_token":      refreshToken,
-			"scope":              scope,
-			"resource":           resource,
-			"audience":           audience,
-			"subject_token":      subjectToken,
-			"subject_token_type": subjectTokenType,
-			"requested_token_type": requestedTokenType,
-			"actor_token":        actorToken,
-			"actor_token_type":   actorTokenType,
-		}, dpop, authorizationHeader)
+		return forwardTokenRequest(ctx, cfg, postForm, dpop, authorizationHeader)
 	}
 
 	if subjectToken == "" {
@@ -257,12 +242,9 @@ func isICTRequest(grantType, requestedTokenType string) bool {
 	return requestedTokenType == "urn:ietf:params:oauth:token-type:ic_token"
 }
 
-func forwardTokenRequest(ctx context.Context, cfg *AppConfiguration, fields map[string]string, dpopProof string, authorizationHeader string) (ImplResponse, error) {
-	form := url.Values{}
-	for key, value := range fields {
-		if value != "" {
-			form.Set(key, value)
-		}
+func forwardTokenRequest(ctx context.Context, cfg *AppConfiguration, form url.Values, dpopProof string, authorizationHeader string) (ImplResponse, error) {
+	if form == nil {
+		form = url.Values{}
 	}
 
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, cfg.TokenEndpoint, strings.NewReader(form.Encode()))


### PR DESCRIPTION
- For non-ICT exchanges the error: "PKCE code verifier not specified" appeared because Middleware did not forward `code_verifier` for normal token exchanges
- Fix: Forward entire form body to include `code_verifier` so Keycloak receives it and can perform PKCE for normal token exchanges